### PR TITLE
capitulo 7: atualiza item 8 do exercício 7.5

### DIFF
--- a/07-testes-automatizados.md
+++ b/07-testes-automatizados.md
@@ -309,7 +309,7 @@ Nesse exercício vamos adicionar um novo `source folder` em nossa aplicação, o
 
 7. Clique no botão **Apply and close** para finalizar a criação do novo source folder.
 
-8. Abra o arquivo `pom.xml`, procure pela tag **<build>** e dentro dela adicione a seguinte tag, logo abaixo da tag **<sourceDirectory>src</sourceDirectory>**:
+8. Abra o arquivo `pom.xml`, procure pela tag `<build>` e dentro dela adicione a seguinte tag, logo abaixo da tag `<sourceDirectory>src</sourceDirectory>`:
 
   ```
   <testSourceDirectory>test</testSourceDirectory>


### PR DESCRIPTION
Formata corretamente as tags de `<build>` e `<sourceDirectory>`, que não estavam aparecendo no markdown e pdf da apostila.